### PR TITLE
bzip2: use purego pkg on CGO_ENABLED=0

### DIFF
--- a/bzip2.go
+++ b/bzip2.go
@@ -1,3 +1,6 @@
+//go:build cgo
+// +build cgo
+
 package binarydist
 
 /*

--- a/bzip2_nocgo.go
+++ b/bzip2_nocgo.go
@@ -1,0 +1,14 @@
+//go:build !cgo
+// +build !cgo
+
+package binarydist
+
+import (
+	"io"
+
+	"github.com/dsnet/compress/bzip2"
+)
+
+func newBzip2Writer(w io.Writer) (wc io.WriteCloser, err error) {
+	return bzip2.NewWriter(w, nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/devsisters/binarydist
 
 go 1.16
+
+require github.com/dsnet/compress v0.0.1


### PR DESCRIPTION
## Changes
In case of using package without CGO, use pure go bzip2 writer when CGO_ENABLED=0